### PR TITLE
Reindex ElasticSearch concurrently by object types

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ Backend /tmp and /files permissions are recursively changed using `setfacl` dire
 Frontends /tmp are also recursively changed
 
 Usage: be3-perms.sh 
+
+## be3-reindex.sh
+
+Shell script to reindex ElasticSearch concurrently, by object type. For usage info, launch the script with no arguments or with `--help` argument.
+
+The script requires `tmux` to be installed and works using the `dbadmin` Cake shell provisioned by BEdita.

--- a/be3-reindex.sh
+++ b/be3-reindex.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+function print_usage () {
+  printf "Usage: ./reindex.sh -t|--types <types> [-c|--concurrency <number>] [-s|--session <name>]\n"
+  printf "\n"
+  printf "\t-t|--types\t\tcomma-separated list of types\n"
+  printf "\t-c|--concurrency\treindex this many types concurrently\n"
+  printf "\t-s|--session\t\ttmux session name, will be created if doesn't exists\n"
+}
+
+# default
+SESSION='reindex'
+CONCURRENCY=4
+TYPES=()
+INITIAL_PANES=0
+
+if [ "$#" -eq "0" ]; then
+  print_usage
+  exit 0
+fi
+
+# read parameters (thanks https://stackoverflow.com/a/14203146/2270403)
+while [[ "$#" -gt "0" ]]; do
+  key="$1"
+
+  case $key in
+      -h|--help)
+      print_usage
+      exit 0
+      ;;
+      -t|--types)
+      OLD_IFS="$IFS"
+      IFS=',' read -r -a TYPES <<< "$2"
+      IFS="$OLD_IFS"
+      shift
+      shift
+      ;;
+      -c|--concurrency)
+      CONCURRENCY="$2"
+      shift
+      shift
+      ;;
+      -s|--session)
+      SESSION="$2"
+      shift
+      shift
+      ;;
+      *)    # unknown option, ignore
+      shift
+      ;;
+  esac
+done
+
+if [ "${#TYPES[@]}" -eq "0" ]; then
+  printf "No types selected\n"
+  exit 1
+fi
+
+printf "Deleting old index and starting reindex for type '%s'\n" "${TYPES[0]}"
+
+if ! tmux has-session -t "$SESSION" > /dev/null 2>&1; then
+  tmux new-session -d -s "$SESSION" "./cake.sh dbadmin rebuildIndex -delete -type ${TYPES[0]}"
+  tmux select-window -t "$SESSION":0
+else
+  tmux select-window -t "$SESSION":0
+  # account for panels already open
+  INITIAL_PANES=$(tmux list-panes -s -t "$SESSION" | wc -l)
+  ((CONCURRENCY += INITIAL_PANES))
+  tmux split-window "./cake.sh dbadmin rebuildIndex -delete -type ${TYPES[0]}"
+  tmux select-layout tiled
+fi
+
+# wait an arbitrary amount of time for index deletion to take effect
+sleep 5
+
+for type in "${TYPES[@]:1}"; do
+  while [ "$(tmux list-panes -s -t "$SESSION" | wc -l)" -ge "$CONCURRENCY" ]; do
+    sleep 3
+  done
+
+  printf "Starting reindex for type '%s'\n" "$type"
+  tmux split-window -t "$SESSION":0.0 "./cake.sh dbadmin rebuildIndex -type $type"
+  tmux select-layout -t "$SESSION":0 tiled
+  sleep 1
+done
+
+# wait for all types to finish
+while [ "$(tmux list-panes -s -t "$SESSION" | wc -l)" -gt "$INITIAL_PANES" ]; do
+  sleep 3
+done
+
+printf "Done"

--- a/be3-reindex.sh
+++ b/be3-reindex.sh
@@ -1,22 +1,55 @@
 #!/bin/bash
 
 function print_usage () {
-  printf "Usage: ./reindex.sh -t|--types <types> [-c|--concurrency <number>] [-s|--session <name>] [-d|--delete]\n"
+  printf "Usage: ./be3-reindex.sh -t|--types <types> [-c|--concurrency <number>] [-s|--session <name>] [-d|--delete]\n"
   printf "\n"
   printf "Available parameters:\n"
-  printf "\t-h|--help\t\tprint this help\n"
-  printf "\t-t|--types\t\tcomma-separated list of types\n"
-  printf "\t-c|--concurrency\treindex this many types concurrently\n"
-  printf "\t-s|--session\t\ttmux session name, will be created if doesn't exists\n"
-  printf "\t-d|--delete\t\tdelete current index before starting\n"
+  printf "\t-h|--help\t\t print this help\n"
+  printf "\t-t|--types\t\t comma-separated list of types\n"
+  printf "\t-c|--concurrency\t reindex this many types concurrently\n"
+  printf "\t-s|--session\t\t tmux session name, will be created if doesn't exists\n"
+  printf "\t-d|--delete\t\t delete current index before starting\n"
+  printf "\t           \t\t WARN: be sure that the first type has few objects, otherwise it will delay all others!\n"
+}
+
+function session_exist () {
+  tmux has-session -t "$SESSION" 2> /dev/null
+}
+
+function select_window () {
+  tmux select-window -t "$SESSION":0
+}
+
+function create_session () {
+  tmux new-session -d -s "$SESSION"
+}
+
+function kill_session () {
+  tmux kill-session -t "$SESSION"
+}
+
+function split_window () {
+  tmux split-window -t "$SESSION":0.0 "$1"
+  tmux select-layout -t "$SESSION":0 tiled
+}
+
+function count_panes () {
+  tmux list-panes -t "$SESSION":0 | wc -l
+}
+
+function current_date () {
+  date +"%F %T"
+}
+
+function current_timestamp () {
+  date +"%s"
 }
 
 # default
 SESSION='reindex'
-CONCURRENCY=4
+MAX_PANES=4
 TYPES=()
 DELETE=0
-INITIAL_PANES=0
 
 if [ "$#" -eq "0" ]; then
   print_usage
@@ -24,7 +57,7 @@ if [ "$#" -eq "0" ]; then
 fi
 
 # read parameters (thanks https://stackoverflow.com/a/14203146/2270403)
-while [[ "$#" -gt "0" ]]; do
+while [ "$#" -gt "0" ]; do
   key="$1"
 
   case $key in
@@ -40,7 +73,7 @@ while [[ "$#" -gt "0" ]]; do
       shift
       ;;
       -c|--concurrency)
-      CONCURRENCY="$2"
+      MAX_PANES="$2"
       shift
       shift
       ;;
@@ -64,56 +97,59 @@ if [ "${#TYPES[@]}" -eq "0" ]; then
   exit 1
 fi
 
-START_TIME="$(date +"%s")"
-COMMAND="echo Reindex of type ${TYPES[0]} && ./cake.sh dbadmin rebuildIndex -type ${TYPES[0]}"
+printf "[%s] Starting reindex of %s types, %s at a time\n" "$(current_date)" "${#TYPES[@]}" "$MAX_PANES"
+START_TIME="$(current_timestamp)"
+DID_CREATE=0
 
-# handle delete parameter
-if [ "$DELETE" -eq "0" ]; then
-  printf "[%s] Starting reindex for type '%s'\n" "$(date +"%F %T")" "${TYPES[0]}"
+if session_exist; then
+  printf "[%s] Using tmux session '%s'\n" "$(current_date)" "$SESSION"
 else
-  COMMAND="$COMMAND -delete"
-  printf "[%s] Deleting old index and starting reindex for type '%s'\n" "$(date +"%F %T")" "${TYPES[0]}"
+  create_session
+  DID_CREATE=1
+  printf "[%s] Created tmux session '%s'\n" "$(current_date)" "$SESSION"
 fi
 
-# start reindex for first type, creating tmux session if needed
-if ! tmux has-session -t "$SESSION" > /dev/null 2>&1; then
-  tmux new-session -d -s "$SESSION" "$COMMAND"
-  tmux select-window -t "$SESSION":0
-else
-  tmux select-window -t "$SESSION":0
-  # account for panels already open
-  INITIAL_PANES="$(tmux list-panes -s -t "$SESSION" | wc -l)"
-  ((CONCURRENCY += INITIAL_PANES))
-  tmux split-window -t "$SESSION":0.0 "$COMMAND"
-  tmux select-layout -t "$SESSION":0 tiled
+INITIAL_PANES="$(count_panes)"
+(( MAX_PANES += INITIAL_PANES ))
+select_window
+
+if [ "$DELETE" -eq "1" ]; then
+  # pop first type from array
+  type="${TYPES[0]}"
+  TYPES=("${TYPES[@]:1}")
+
+  printf "[%s] Deleting old index and starting reindex of type '%s'\n" "$(current_date)" "$type"
+  split_window "echo Reindex of type $type && ./cake.sh dbadmin rebuildIndex -delete -type $type"
+
+  # wait first type to finish
+  while [ "$(count_panes)" -gt "$INITIAL_PANES" ]; do
+    sleep 1
+  done
 fi
 
-# wait an arbitrary amount of time for index deletion to take effect
-sleep 5
-
-# reindex all types
-for type in "${TYPES[@]:1}"; do
-  while [ "$(tmux list-panes -s -t "$SESSION" | wc -l)" -ge "$CONCURRENCY" ]; do
-    sleep 3
+for type in "${TYPES[@]}"; do
+  while [ "$(count_panes)" -ge "$MAX_PANES" ]; do
+    sleep 1
   done
 
-  printf "[%s] Starting reindex for type '%s'\n" "$(date +"%F %T")" "$type"
-  tmux split-window -t "$SESSION":0.0 "echo Reindex of type $type && ./cake.sh dbadmin rebuildIndex -type $type"
-  tmux select-layout -t "$SESSION":0 tiled
+  printf "[%s] Starting reindex of type '%s'\n" "$(current_date)" "$type"
+  split_window "echo Reindex of type $type && ./cake.sh dbadmin rebuildIndex -type $type"
   sleep 1
 done
 
-printf "[%s] All types started, waiting for reindex to finish..." "$(date +"%F %T")"
+printf "[%s] All types started, waiting for reindex to finish..." "$(current_date)"
 
 # wait for all types to finish
-while [ "$(tmux list-panes -s -t "$SESSION" | wc -l)" -gt "$INITIAL_PANES" ]; do
-  sleep 3
-
-  if ! tmux has-session -t "$SESSION" > /dev/null 2>&1; then
-    break
-  fi
+while [ "$(count_panes)" -gt "$INITIAL_PANES" ]; do
+  sleep 1
 done
 
 printf "done!\n"
-ELAPSED_TIME=$(($(date +"%s") - "$START_TIME"))
-printf "[%s] Total elapsed time: %s\n" "$(date +"%F %T")" "$(date -u -d @"$ELAPSED_TIME" +"%T")"
+END_TIME="$(current_timestamp)"
+ELAPSED_TIME="$((END_TIME - START_TIME))"
+printf "[%s] Total elapsed time: %s\n" "$(current_date)" "$(date -u -d @"$ELAPSED_TIME" +"%T")"
+
+# kill session if we created it
+if [ "$DID_CREATE" -eq "1" ]; then
+  kill_session
+fi

--- a/be3-reindex.sh
+++ b/be3-reindex.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 
 function print_usage () {
-  printf "Usage: ./reindex.sh -t|--types <types> [-c|--concurrency <number>] [-s|--session <name>]\n"
+  printf "Usage: ./reindex.sh -t|--types <types> [-c|--concurrency <number>] [-s|--session <name>] [-d|--delete]\n"
   printf "\n"
+  printf "Available parameters:\n"
+  printf "\t-h|--help\t\tprint this help\n"
   printf "\t-t|--types\t\tcomma-separated list of types\n"
   printf "\t-c|--concurrency\treindex this many types concurrently\n"
   printf "\t-s|--session\t\ttmux session name, will be created if doesn't exists\n"
+  printf "\t-d|--delete\t\tdelete current index before starting\n"
 }
 
 # default
 SESSION='reindex'
 CONCURRENCY=4
 TYPES=()
+DELETE=0
 INITIAL_PANES=0
 
 if [ "$#" -eq "0" ]; then
@@ -45,6 +49,10 @@ while [[ "$#" -gt "0" ]]; do
       shift
       shift
       ;;
+      -d|--delete)
+      DELETE=1
+      shift
+      ;;
       *)    # unknown option, ignore
       shift
       ;;
@@ -56,37 +64,56 @@ if [ "${#TYPES[@]}" -eq "0" ]; then
   exit 1
 fi
 
-printf "Deleting old index and starting reindex for type '%s'\n" "${TYPES[0]}"
+START_TIME="$(date +"%s")"
+COMMAND="echo Reindex of type ${TYPES[0]} && ./cake.sh dbadmin rebuildIndex -type ${TYPES[0]}"
 
+# handle delete parameter
+if [ "$DELETE" -eq "0" ]; then
+  printf "[%s] Starting reindex for type '%s'\n" "$(date +"%F %T")" "${TYPES[0]}"
+else
+  COMMAND="$COMMAND -delete"
+  printf "[%s] Deleting old index and starting reindex for type '%s'\n" "$(date +"%F %T")" "${TYPES[0]}"
+fi
+
+# start reindex for first type, creating tmux session if needed
 if ! tmux has-session -t "$SESSION" > /dev/null 2>&1; then
-  tmux new-session -d -s "$SESSION" "./cake.sh dbadmin rebuildIndex -delete -type ${TYPES[0]}"
+  tmux new-session -d -s "$SESSION" "$COMMAND"
   tmux select-window -t "$SESSION":0
 else
   tmux select-window -t "$SESSION":0
   # account for panels already open
-  INITIAL_PANES=$(tmux list-panes -s -t "$SESSION" | wc -l)
+  INITIAL_PANES="$(tmux list-panes -s -t "$SESSION" | wc -l)"
   ((CONCURRENCY += INITIAL_PANES))
-  tmux split-window "./cake.sh dbadmin rebuildIndex -delete -type ${TYPES[0]}"
-  tmux select-layout tiled
+  tmux split-window -t "$SESSION":0.0 "$COMMAND"
+  tmux select-layout -t "$SESSION":0 tiled
 fi
 
 # wait an arbitrary amount of time for index deletion to take effect
 sleep 5
 
+# reindex all types
 for type in "${TYPES[@]:1}"; do
   while [ "$(tmux list-panes -s -t "$SESSION" | wc -l)" -ge "$CONCURRENCY" ]; do
     sleep 3
   done
 
-  printf "Starting reindex for type '%s'\n" "$type"
-  tmux split-window -t "$SESSION":0.0 "./cake.sh dbadmin rebuildIndex -type $type"
+  printf "[%s] Starting reindex for type '%s'\n" "$(date +"%F %T")" "$type"
+  tmux split-window -t "$SESSION":0.0 "echo Reindex of type $type && ./cake.sh dbadmin rebuildIndex -type $type"
   tmux select-layout -t "$SESSION":0 tiled
   sleep 1
 done
 
+printf "[%s] All types started, waiting for reindex to finish..." "$(date +"%F %T")"
+
 # wait for all types to finish
 while [ "$(tmux list-panes -s -t "$SESSION" | wc -l)" -gt "$INITIAL_PANES" ]; do
   sleep 3
+
+  if ! tmux has-session -t "$SESSION" > /dev/null 2>&1; then
+    break
+  fi
 done
 
-printf "Done"
+printf "done!\n"
+ELAPSED_TIME=$(($(date +"%s") - "$START_TIME"))
+printf "[%s] Total elapsed time: %s\n" "$(date +"%F %T")" "$(date -u -d @"$ELAPSED_TIME" +"%T")"

--- a/be3-reindex.sh
+++ b/be3-reindex.sh
@@ -1,55 +1,133 @@
 #!/bin/bash
 
-function print_usage () {
-  printf "Usage: ./be3-reindex.sh -t|--types <types> [-c|--concurrency <number>] [-s|--session <name>] [-d|--delete]\n"
+print_usage() {
+  printf "Usage: ./reindex.sh [-t|--types <types>] [--min <number> --max <number>] [-c|--concurrency <number>] [-s|--session <name>] [-d|--delete]\n"
+  printf "\n"
+  printf "This script is used to concurrently reindex objects in the configured search engine.\n"
+  printf "Reindexing of objects can be made concurrently by specifying either multiple object types or min/max IDs.\n"
   printf "\n"
   printf "Available parameters:\n"
-  printf "\t-h|--help\t\t print this help\n"
-  printf "\t-t|--types\t\t comma-separated list of types\n"
-  printf "\t-c|--concurrency\t reindex this many types concurrently\n"
-  printf "\t-s|--session\t\t tmux session name, will be created if doesn't exists\n"
-  printf "\t-d|--delete\t\t delete current index before starting\n"
-  printf "\t           \t\t WARN: be sure that the first type has few objects, otherwise it will delay all others!\n"
+  printf "\t -h|--help\n"
+  printf "\t\t print this help\n\n"
+  printf "\t -t|--types <types>\n"
+  printf "\t\t comma-separated list of object types\n"
+  printf "\t\t WARN: mutually exclusive with --min and --max parameters\n\n"
+  printf "\t --min <number> | --max <number>\n"
+  printf "\t\t minimum and maximum object ID to index\n"
+  printf "\t\t WARN: both must be defined; mutually exclusive with --types parameter\n\n"
+  printf "\t -c|--concurrency <number>\n"
+  printf "\t\t concurrent reindex shells\n\n"
+  printf "\t -s|--session <name>\n"
+  printf "\t\t tmux session name, will be created if doesn't exists\n\n"
+  printf "\t -d|--delete\n"
+  printf "\t\t delete current index before starting\n"
+  printf "\t\t WARN: if using object types, be sure that the first type has few objects otherwise it will delay all others!\n\n"
+  printf "\t -l|--log\n"
+  printf "\t\t log errors in rebuildIndex.log file\n\n"
 }
 
-function session_exist () {
+session_exist() {
   tmux has-session -t "$SESSION" 2> /dev/null
 }
 
-function select_window () {
+select_window() {
   tmux select-window -t "$SESSION":0
 }
 
-function create_session () {
+create_session() {
   tmux new-session -d -s "$SESSION"
 }
 
-function kill_session () {
+kill_session() {
   tmux kill-session -t "$SESSION"
 }
 
-function split_window () {
+split_window() {
   tmux split-window -t "$SESSION":0.0 "$1"
   tmux select-layout -t "$SESSION":0 tiled
 }
 
-function count_panes () {
+count_panes() {
   tmux list-panes -t "$SESSION":0 | wc -l
 }
 
-function current_date () {
+current_time() {
   date +"%F %T"
 }
 
-function current_timestamp () {
+current_timestamp() {
   date +"%s"
+}
+
+reindex_by_types() {
+  printf "[%s] Starting reindex of %s types, %s at a time\n" "$(current_time)" "${#TYPES[@]}" "$MAX_PANES"
+  
+  if [ "$DELETE" -eq "1" ]; then
+    # pop first type from array
+    type="${TYPES[0]}"
+    TYPES=("${TYPES[@]:1}")
+
+    printf "[%s] Deleting old index and starting reindex of type '%s'\n" "$(current_time)" "$type"
+    split_window "echo Reindex of type $type && ./cake.sh dbadmin rebuildIndex -delete -type $type$LOG"
+  
+    # wait first type to finish
+    while [ "$(count_panes)" -gt "$INITIAL_PANES" ]; do
+      sleep 1
+    done
+  fi
+  
+  for type in "${TYPES[@]}"; do
+    while [ "$(count_panes)" -ge "$(( MAX_PANES + INITIAL_PANES ))" ]; do
+      sleep 1
+    done
+  
+    printf "[%s] Starting reindex of type '%s'\n" "$(current_time)" "$type"
+    split_window "echo Reindex of type $type && ./cake.sh dbadmin rebuildIndex -type $type$LOG"
+    sleep 1
+  done
+}
+
+reindex_by_ids() {
+  printf "[%s] Starting reindex of %s objects, %s at a time\n" "$(current_time)" "$(( 1 + $MAX_ID - $MIN_ID ))" "$MAX_PANES"
+  
+  size="$(( ($MAX_ID - $MIN_ID) / $MAX_PANES ))"
+  start_id="$MIN_ID"
+  end_id="$(( start_id + size ))"
+
+  if [ "$DELETE" -eq "1" ]; then
+    printf "[%s] Deleting old index and starting reindex from object ID %s\n" "$(current_time)" "$start_id"
+    split_window "echo Reindex of object $start_id && ./cake.sh dbadmin rebuildIndex -delete -id $start_id$LOG"
+    (( start_id += 1 ))
+  
+    # wait first type to finish
+    while [ "$(count_panes)" -gt "$INITIAL_PANES" ]; do
+      sleep 1
+    done
+  fi
+  
+  while [ "$start_id" -le "$MAX_ID" ]; do
+    while [ "$(count_panes)" -ge "$(( MAX_PANES + INITIAL_PANES ))" ]; do
+      sleep 1
+    done
+
+    printf "[%s] Starting reindex of objects in range %s-%s\n" "$(current_time)" "$start_id" "$end_id"
+    split_window "echo Reindex of range $start_id-$end_id && ./cake.sh dbadmin rebuildIndex -min $start_id -max $end_id$LOG"
+    start_id="$(( end_id + 1 ))"
+    end_id="$(( start_id + size ))"
+    if [ "$end_id" -gt "$MAX_ID" ]; then
+      end_id="$MAX_ID"
+    fi
+  done
 }
 
 # default
 SESSION='reindex'
-MAX_PANES=4
+MAX_PANES="$(getconf _NPROCESSORS_ONLN)"
 TYPES=()
+MIN_ID=
+MAX_ID=
 DELETE=0
+LOG=
 
 if [ "$#" -eq "0" ]; then
   print_usage
@@ -61,85 +139,93 @@ while [ "$#" -gt "0" ]; do
   key="$1"
 
   case $key in
-      -h|--help)
+    -h|--help)
       print_usage
       exit 0
       ;;
-      -t|--types)
+    -t|--types)
       OLD_IFS="$IFS"
       IFS=',' read -r -a TYPES <<< "$2"
       IFS="$OLD_IFS"
       shift
       shift
       ;;
-      -c|--concurrency)
+    --min)
+      MIN_ID="$2"
+      shift
+      shift
+      ;;
+    --max)
+      MAX_ID="$2"
+      shift
+      shift
+      ;;
+    -c|--concurrency)
       MAX_PANES="$2"
       shift
       shift
       ;;
-      -s|--session)
+    -s|--session)
       SESSION="$2"
       shift
       shift
       ;;
-      -d|--delete)
+    -d|--delete)
       DELETE=1
       shift
       ;;
-      *)    # unknown option, ignore
+    -l|--log)
+      LOG=" -log"
+      shift
+      ;;
+    *) # unknown option, ignore
       shift
       ;;
   esac
 done
 
-if [ "${#TYPES[@]}" -eq "0" ]; then
-  printf "No types selected\n"
+if ([ -n "$MIN_ID" ] || [ -n "$MAX_ID" ]) && [ "${#TYPES[@]}" -gt "0" ]; then
+  printf "Parameters --types and --min|--max are mutually exclusive\n"
   exit 1
 fi
 
-printf "[%s] Starting reindex of %s types, %s at a time\n" "$(current_date)" "${#TYPES[@]}" "$MAX_PANES"
+if ([ -n "$MIN_ID" ] && [ -z "$MAX_ID" ]) || ([ -z "$MIN_ID" ] && [ -n "$MAX_ID" ]); then
+  printf "Both --min and --max must be defined\n"
+  exit 1
+fi
+
+if [ -z "$MIN_ID" ] && [ -z "$MAX_ID" ] && [ "${#TYPES[@]}" -eq "0" ]; then
+  printf "Either --types or --min|--max must be defined\n"
+  exit 1
+fi
+
 START_TIME="$(current_timestamp)"
 DID_CREATE=0
 
 if session_exist; then
-  printf "[%s] Using tmux session '%s'\n" "$(current_date)" "$SESSION"
+  printf "[%s] Using tmux session '%s'\n" "$(current_time)" "$SESSION"
 else
   create_session
   DID_CREATE=1
-  printf "[%s] Created tmux session '%s'\n" "$(current_date)" "$SESSION"
+  printf "[%s] Created tmux session '%s'\n" "$(current_time)" "$SESSION"
 fi
 
 INITIAL_PANES="$(count_panes)"
-(( MAX_PANES += INITIAL_PANES ))
+#(( MAX_PANES += INITIAL_PANES ))
 select_window
 
-if [ "$DELETE" -eq "1" ]; then
-  # pop first type from array
-  type="${TYPES[0]}"
-  TYPES=("${TYPES[@]:1}")
-
-  printf "[%s] Deleting old index and starting reindex of type '%s'\n" "$(current_date)" "$type"
-  split_window "echo Reindex of type $type && ./cake.sh dbadmin rebuildIndex -delete -type $type"
-
-  # wait first type to finish
-  while [ "$(count_panes)" -gt "$INITIAL_PANES" ]; do
-    sleep 1
-  done
+if [ "${#TYPES[@]}" -gt "0" ]; then
+  reindex_by_types
+elif [ -n "$MIN_ID" ] && [ -n "$MAX_ID" ]; then
+  reindex_by_ids
+else
+  printf "How did you get here?\n"
+  exit 1
 fi
+  
+printf "[%s] All reindexing started, waiting to finish..." "$(current_time)"
 
-for type in "${TYPES[@]}"; do
-  while [ "$(count_panes)" -ge "$MAX_PANES" ]; do
-    sleep 1
-  done
-
-  printf "[%s] Starting reindex of type '%s'\n" "$(current_date)" "$type"
-  split_window "echo Reindex of type $type && ./cake.sh dbadmin rebuildIndex -type $type"
-  sleep 1
-done
-
-printf "[%s] All types started, waiting for reindex to finish..." "$(current_date)"
-
-# wait for all types to finish
+# wait for all reindexing to finish
 while [ "$(count_panes)" -gt "$INITIAL_PANES" ]; do
   sleep 1
 done
@@ -147,7 +233,7 @@ done
 printf "done!\n"
 END_TIME="$(current_timestamp)"
 ELAPSED_TIME="$((END_TIME - START_TIME))"
-printf "[%s] Total elapsed time: %s\n" "$(current_date)" "$(date -u -d @"$ELAPSED_TIME" +"%T")"
+printf "[%s] Total elapsed time: %s\n" "$(current_time)" "$(date -u -d @"$ELAPSED_TIME" +"%T")"
 
 # kill session if we created it
 if [ "$DID_CREATE" -eq "1" ]; then


### PR DESCRIPTION
This PR adds a bash script to parallelize reindex of ElasticSearch.

The script requires tmux and cake.sh, and is dependent on the dbadmin Cake shell to handle the actual reindex. It accepts a few arguments:
```
         -h|--help
                 print this help

         -t|--types <types>
                 comma-separated list of object types
                 WARN: mutually exclusive with --min and --max parameters

         --min <number> | --max <number>
                 minimum and maximum object ID to index
                 WARN: both must be defined; mutually exclusive with --types parameter

         -c|--concurrency <number>
                 concurrent reindex shells

         -s|--session <name>
                 tmux session name, will be created if doesn't exists

         -d|--delete
                 delete current index before starting
                 WARN: if using object types, be sure that the first type has few objects otherwise it will delay all others!

         -l|--log
                 log errors in rebuildIndex.log file
```

When started It will run the reindex for the first type/object ID with the -delete flag, then will run a reindex for each type or ID range in a separate tmux pane. Don't increase concurrency too much, reindexing is a cpu-intense task!

So far It's not a completely automated task since the dbadmin Cake shell requires user interaction if reindexing fails (see https://github.com/bedita/bedita/blob/3-corylus/bedita-app/vendors/shells/dbadmin.php#L142), so you should attach to the tmux session after starting this script.